### PR TITLE
Fix link to account

### DIFF
--- a/app/Http/Controllers/Import/ConfigurationController.php
+++ b/app/Http/Controllers/Import/ConfigurationController.php
@@ -114,7 +114,7 @@ class ConfigurationController extends Controller
                     $bunqAccount['ff3_type']     = $ff3Account->type;
                     $bunqAccount['ff3_iban']     = $ff3Account->iban;
                     $bunqAccount['ff3_currency'] = $ff3Account->currencyCode;
-                    $bunqAccount['ff3_url']      = sprintf('%saccounts/show/%d', $url, $ff3Account->id);
+                    $bunqAccount['ff3_url']      = sprintf('%s/accounts/show/%d', $url, $ff3Account->id);
                 }
             }
             $combinedAccounts[] = $bunqAccount;


### PR DESCRIPTION
Add a trailing slash to ff3_url.

Before change the url would look like this: `https://example.comaccounts/show/6`  
After: `https://example.com/accounts/show/6`  

I also tried fixing this by adding a slash to `FIREFLY_III_URL` but that creates an [error](https://gist.github.com/rubenvanerk/bd870412159e041560d5b07647d8d173).

@JC5
